### PR TITLE
Refactor npc model to hold potion

### DIFF
--- a/manifests/dev/base/abis/models/bytebeasts-NPC-4c5239ac.json
+++ b/manifests/dev/base/abis/models/bytebeasts-NPC-4c5239ac.json
@@ -440,6 +440,24 @@
   },
   {
     "type": "struct",
+    "name": "bytebeasts::models::potion::Potion",
+    "members": [
+      {
+        "name": "potion_id",
+        "type": "core::integer::u32"
+      },
+      {
+        "name": "potion_name",
+        "type": "core::felt252"
+      },
+      {
+        "name": "potion_effect",
+        "type": "core::integer::u32"
+      }
+    ]
+  },
+  {
+    "type": "struct",
     "name": "bytebeasts::models::npc::NPC",
     "members": [
       {
@@ -485,6 +503,10 @@
       {
         "name": "experience_points",
         "type": "core::integer::u16"
+      },
+      {
+        "name": "potions",
+        "type": "core::array::Array::<bytebeasts::models::potion::Potion>"
       }
     ]
   },

--- a/manifests/dev/base/models/bytebeasts-NPC-4c5239ac.toml
+++ b/manifests/dev/base/models/bytebeasts-NPC-4c5239ac.toml
@@ -1,6 +1,6 @@
 kind = "DojoModel"
-class_hash = "0x55ecd947ecdaf70c5e78ba1297ced3412418866c577b58a58fdabeef1accfd8"
-original_class_hash = "0x55ecd947ecdaf70c5e78ba1297ced3412418866c577b58a58fdabeef1accfd8"
+class_hash = "0x3ba44df67a037c20f004b7f5ab7725932d4519eed6beb6bc223a03e96c0f0f9"
+original_class_hash = "0x3ba44df67a037c20f004b7f5ab7725932d4519eed6beb6bc223a03e96c0f0f9"
 abi = "manifests/dev/base/abis/models/bytebeasts-NPC-4c5239ac.json"
 tag = "bytebeasts-NPC"
 manifest_name = "bytebeasts-NPC-4c5239ac"
@@ -58,4 +58,9 @@ key = false
 [[members]]
 name = "experience_points"
 type = "u16"
+key = false
+
+[[members]]
+name = "potions"
+type = "Array<Potion>"
 key = false

--- a/src/models/npc.cairo
+++ b/src/models/npc.cairo
@@ -1,6 +1,9 @@
 use super::role::Role;
 use super::coordinates::Coordinates;
 use super::mission_status::MissionStatus;
+use super::potion::Potion;
+
+use array::ArrayTrait; 
 
 #[derive(Drop, Serde)]
 #[dojo::model]
@@ -17,18 +20,20 @@ pub struct NPC {
     pub mission_status: MissionStatus, // Status of the mission associated with the NPC
     pub reward: u16, // Fixed reward given by the NPC
     pub experience_points: u16, // Experience points given by the NPC
+    pub potions: Array<Potion>, // Items held by the NPC
 }
 
 
 #[cfg(test)]
 mod tests {
     use bytebeasts::{
-        models::{role::Role, coordinates::Coordinates, mission_status::MissionStatus, npc::NPC},
+        models::{role::Role, coordinates::Coordinates, mission_status::MissionStatus, npc::NPC, potion::Potion},
     };
+    use array::ArrayTrait; 
 
     #[test]
     fn test_npc_creation() {
-        let npc = NPC {
+        let mut npc = NPC {
             npc_id: 1,
             npc_name: 'Gandalf',
             npc_description: 'A wise old wizard',
@@ -40,7 +45,15 @@ mod tests {
             mission_status: MissionStatus::NotStarted,
             reward: 50,
             experience_points: 100,
+            potions: ArrayTrait::new(),
         };
+        let potion = Potion {
+            potion_id: 1,
+            potion_name: 'Restore everything',
+            potion_effect: 50,
+        };
+
+        npc.potions.append(potion);
 
         assert_eq!(npc.npc_id, 1);
         assert_eq!(npc.npc_name, 'Gandalf');
@@ -53,6 +66,8 @@ mod tests {
         assert_eq!(npc.mission_status.into(), 0); // MissionStatus::NotStarted -> 0
         assert_eq!(npc.reward, 50);
         assert_eq!(npc.experience_points, 100);
+        assert_eq!(npc.potions.len(), 1, "NPC should have 1 potion");
+        assert_eq!(npc.potions.pop_front().unwrap().potion_id, 1, "NPC potion ID should be 1");
     }
 
     #[test]


### PR DESCRIPTION
## Summary 
- Closes #27 
- This PR enables the NPCs the ability to hold items, at this moment just potions.
- I used an array to make simple the validations in the future.