### PR TITLE
Feat add bag item actions

### DIFF
--- a/manifests/dev/base/abis/contracts/bytebeasts-bag_system-7ad8a155.json
+++ b/manifests/dev/base/abis/contracts/bytebeasts-bag_system-7ad8a155.json
@@ -1,0 +1,283 @@
+[
+  {
+    "type": "impl",
+    "name": "ContractImpl",
+    "interface_name": "dojo::contract::contract::IContract"
+  },
+  {
+    "type": "struct",
+    "name": "core::byte_array::ByteArray",
+    "members": [
+      {
+        "name": "data",
+        "type": "core::array::Array::<core::bytes_31::bytes31>"
+      },
+      {
+        "name": "pending_word",
+        "type": "core::felt252"
+      },
+      {
+        "name": "pending_word_len",
+        "type": "core::integer::u32"
+      }
+    ]
+  },
+  {
+    "type": "interface",
+    "name": "dojo::contract::contract::IContract",
+    "items": [
+      {
+        "type": "function",
+        "name": "contract_name",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::byte_array::ByteArray"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "namespace",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::byte_array::ByteArray"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "tag",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::byte_array::ByteArray"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "name_hash",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::felt252"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "namespace_hash",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::felt252"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "selector",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::felt252"
+          }
+        ],
+        "state_mutability": "view"
+      }
+    ]
+  },
+  {
+    "type": "impl",
+    "name": "WorldProviderImpl",
+    "interface_name": "dojo::world::world_contract::IWorldProvider"
+  },
+  {
+    "type": "struct",
+    "name": "dojo::world::world_contract::IWorldDispatcher",
+    "members": [
+      {
+        "name": "contract_address",
+        "type": "core::starknet::contract_address::ContractAddress"
+      }
+    ]
+  },
+  {
+    "type": "interface",
+    "name": "dojo::world::world_contract::IWorldProvider",
+    "items": [
+      {
+        "type": "function",
+        "name": "world",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "dojo::world::world_contract::IWorldDispatcher"
+          }
+        ],
+        "state_mutability": "view"
+      }
+    ]
+  },
+  {
+    "type": "impl",
+    "name": "BagActionImpl",
+    "interface_name": "bytebeasts::systems::bag::IBagAction"
+  },
+  {
+    "type": "struct",
+    "name": "bytebeasts::models::potion::Potion",
+    "members": [
+      {
+        "name": "potion_id",
+        "type": "core::integer::u32"
+      },
+      {
+        "name": "potion_name",
+        "type": "core::felt252"
+      },
+      {
+        "name": "potion_effect",
+        "type": "core::integer::u32"
+      }
+    ]
+  },
+  {
+    "type": "interface",
+    "name": "bytebeasts::systems::bag::IBagAction",
+    "items": [
+      {
+        "type": "function",
+        "name": "init_bag",
+        "inputs": [
+          {
+            "name": "bag_id",
+            "type": "core::integer::u32"
+          },
+          {
+            "name": "player_id",
+            "type": "core::integer::u32"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
+        "name": "add_item",
+        "inputs": [
+          {
+            "name": "player_id",
+            "type": "core::integer::u32"
+          },
+          {
+            "name": "potion",
+            "type": "bytebeasts::models::potion::Potion"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
+        "name": "take_out_item",
+        "inputs": [
+          {
+            "name": "player_id",
+            "type": "core::integer::u32"
+          }
+        ],
+        "outputs": [
+          {
+            "type": "bytebeasts::models::potion::Potion"
+          }
+        ],
+        "state_mutability": "external"
+      }
+    ]
+  },
+  {
+    "type": "impl",
+    "name": "IDojoInitImpl",
+    "interface_name": "bytebeasts::systems::bag::bag_system::IDojoInit"
+  },
+  {
+    "type": "interface",
+    "name": "bytebeasts::systems::bag::bag_system::IDojoInit",
+    "items": [
+      {
+        "type": "function",
+        "name": "dojo_init",
+        "inputs": [],
+        "outputs": [],
+        "state_mutability": "view"
+      }
+    ]
+  },
+  {
+    "type": "impl",
+    "name": "UpgradableImpl",
+    "interface_name": "dojo::contract::upgradeable::IUpgradeable"
+  },
+  {
+    "type": "interface",
+    "name": "dojo::contract::upgradeable::IUpgradeable",
+    "items": [
+      {
+        "type": "function",
+        "name": "upgrade",
+        "inputs": [
+          {
+            "name": "new_class_hash",
+            "type": "core::starknet::class_hash::ClassHash"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "dojo::contract::upgradeable::upgradeable::Upgraded",
+    "kind": "struct",
+    "members": [
+      {
+        "name": "class_hash",
+        "type": "core::starknet::class_hash::ClassHash",
+        "kind": "data"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "dojo::contract::upgradeable::upgradeable::Event",
+    "kind": "enum",
+    "variants": [
+      {
+        "name": "Upgraded",
+        "type": "dojo::contract::upgradeable::upgradeable::Upgraded",
+        "kind": "nested"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "bytebeasts::systems::bag::bag_system::Event",
+    "kind": "enum",
+    "variants": [
+      {
+        "name": "UpgradeableEvent",
+        "type": "dojo::contract::upgradeable::upgradeable::Event",
+        "kind": "nested"
+      }
+    ]
+  }
+]

--- a/manifests/dev/base/abis/contracts/bytebeasts-bag_system-7ad8a155.json
+++ b/manifests/dev/base/abis/contracts/bytebeasts-bag_system-7ad8a155.json
@@ -178,6 +178,10 @@
             "type": "core::integer::u32"
           },
           {
+            "name": "bag_id",
+            "type": "core::integer::u32"
+          },
+          {
             "name": "potion",
             "type": "bytebeasts::models::potion::Potion"
           }
@@ -191,6 +195,10 @@
         "inputs": [
           {
             "name": "player_id",
+            "type": "core::integer::u32"
+          },
+          {
+            "name": "bag_id",
             "type": "core::integer::u32"
           }
         ],

--- a/manifests/dev/base/contracts/bytebeasts-bag_system-7ad8a155.toml
+++ b/manifests/dev/base/contracts/bytebeasts-bag_system-7ad8a155.toml
@@ -1,0 +1,10 @@
+kind = "DojoContract"
+class_hash = "0x7af44dbe59227afb63dc4812715c8a103e7dc8d620d795fd5e122867714da92"
+original_class_hash = "0x7af44dbe59227afb63dc4812715c8a103e7dc8d620d795fd5e122867714da92"
+base_class_hash = "0x0"
+abi = "manifests/dev/base/abis/contracts/bytebeasts-bag_system-7ad8a155.json"
+reads = []
+writes = []
+init_calldata = []
+tag = "bytebeasts-bag_system"
+manifest_name = "bytebeasts-bag_system-7ad8a155"

--- a/manifests/dev/base/contracts/bytebeasts-bag_system-7ad8a155.toml
+++ b/manifests/dev/base/contracts/bytebeasts-bag_system-7ad8a155.toml
@@ -1,6 +1,6 @@
 kind = "DojoContract"
-class_hash = "0x7af44dbe59227afb63dc4812715c8a103e7dc8d620d795fd5e122867714da92"
-original_class_hash = "0x7af44dbe59227afb63dc4812715c8a103e7dc8d620d795fd5e122867714da92"
+class_hash = "0x51aaf7a580665ebd6d7d32e2340f0e8b6850296fc1ad389c74a293d1a26029f"
+original_class_hash = "0x51aaf7a580665ebd6d7d32e2340f0e8b6850296fc1ad389c74a293d1a26029f"
 base_class_hash = "0x0"
 abi = "manifests/dev/base/abis/contracts/bytebeasts-bag_system-7ad8a155.json"
 reads = []

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -27,4 +27,5 @@ mod models {
 
 mod tests {
     mod test_battle;
+    mod test_bag;
 }

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -4,6 +4,7 @@ mod systems {
     mod move;
     mod spawn;
     mod world_setup;
+    mod bag;
 }
 
 mod models {

--- a/src/systems/bag.cairo
+++ b/src/systems/bag.cairo
@@ -1,0 +1,49 @@
+use dojo::world::{IWorldDispatcher, IWorldDispatcherTrait};
+use bytebeasts::{
+    models::{player::Player, potion::Potion, bag::Bag},
+};
+
+#[dojo::interface]
+trait IBagAction {
+    fn init_bag(ref world: IWorldDispatcher, bag_id: u32, player_id: u32);
+    fn add_item(ref world: IWorldDispatcher, player_id: u32, potion: Potion);
+    fn take_out_item(ref world: IWorldDispatcher, player_id: u32) -> Potion;
+}
+
+#[dojo::contract]
+mod bag_system {
+    use super::IBagAction;
+    use array::ArrayTrait; 
+    use bytebeasts::{
+        models::{player::Player, potion::Potion, bag::Bag},
+    };
+
+    const MAX_BAG_SIZE: usize = 10;
+
+    #[abi(embed_v0)]
+    impl BagActionImpl of IBagAction<ContractState> {
+        fn init_bag(ref world: IWorldDispatcher, bag_id: u32, player_id: u32) {
+            let bag = Bag {
+                bag_id: bag_id,
+                player_id: player_id,
+                max_capacity: MAX_BAG_SIZE,
+                potions: ArrayTrait::new(),
+            };
+
+            set!(world, (bag))
+        }
+
+        fn add_item(ref world: IWorldDispatcher, player_id: u32, potion: Potion) {
+            let mut bag = get!(world,player_id,(Bag));
+            bag.potions.append(potion);
+            set!(world, (bag));
+        }
+
+        fn take_out_item(ref world: IWorldDispatcher, player_id: u32) -> Potion {
+            let mut bag = get!(world,player_id,(Bag));
+            let potion = bag.potions.pop_front().unwrap();
+            set!(world, (bag));
+            return potion;
+        }
+    }
+}

--- a/src/systems/bag.cairo
+++ b/src/systems/bag.cairo
@@ -6,8 +6,8 @@ use bytebeasts::{
 #[dojo::interface]
 trait IBagAction {
     fn init_bag(ref world: IWorldDispatcher, bag_id: u32, player_id: u32);
-    fn add_item(ref world: IWorldDispatcher, player_id: u32, potion: Potion);
-    fn take_out_item(ref world: IWorldDispatcher, player_id: u32) -> Potion;
+    fn add_item(ref world: IWorldDispatcher, player_id: u32, bag_id: u32, potion: Potion);
+    fn take_out_item(ref world: IWorldDispatcher, player_id: u32, bag_id: u32) -> Potion;
 }
 
 #[dojo::contract]
@@ -33,14 +33,14 @@ mod bag_system {
             set!(world, (bag))
         }
 
-        fn add_item(ref world: IWorldDispatcher, player_id: u32, potion: Potion) {
-            let mut bag = get!(world,player_id,(Bag));
+        fn add_item(ref world: IWorldDispatcher, player_id: u32, bag_id: u32, potion: Potion) {
+            let mut bag = get!(world, (bag_id, player_id), (Bag));
             bag.potions.append(potion);
             set!(world, (bag));
         }
 
-        fn take_out_item(ref world: IWorldDispatcher, player_id: u32) -> Potion {
-            let mut bag = get!(world,player_id,(Bag));
+        fn take_out_item(ref world: IWorldDispatcher, player_id: u32, bag_id: u32) -> Potion {
+            let mut bag = get!(world, (bag_id, player_id), (Bag));
             let potion = bag.potions.pop_front().unwrap();
             set!(world, (bag));
             return potion;

--- a/src/tests/test_bag.cairo
+++ b/src/tests/test_bag.cairo
@@ -38,9 +38,39 @@ mod tests {
         (world, bag_system)
     }
 
+    
+    #[test]
+    fn test_setup_player_bag()  -> (IWorldDispatcher, IBagActionDispatcher) {
+        let (world, bag_system) = setup_world();
+
+        let player_ash = Player {
+            player_id: 1,
+            player_name: 'Ash',
+            beast_1: 1, // Beast 1 assigned
+            beast_2: 0, // No beast assigned
+            beast_3: 0, // No beast assigned
+            beast_4: 0, // No beast assigned
+            potions: 2
+        };
+
+        let bag = Bag {
+            bag_id: 1,
+            player_id: 1,
+            max_capacity: 10,
+            potions: ArrayTrait::new(),
+        };
+        
+        set!(world,(player_ash));
+
+        set!(world,(bag));
+
+        (world, bag_system)
+    }
 
     #[test]
     fn test_setup() {
         let (_, _,) = setup_world();
+        let (_, _,) = test_setup_player_bag();
+        
     }
 }

--- a/src/tests/test_bag.cairo
+++ b/src/tests/test_bag.cairo
@@ -1,0 +1,46 @@
+#[cfg(test)]
+mod tests {
+    use starknet::ContractAddress;
+
+    use dojo::world::{IWorldDispatcher, IWorldDispatcherTrait}; 
+    use dojo::utils::test::{spawn_test_world, deploy_contract};
+
+    use bytebeasts::{
+        systems::{bag::{bag_system, IBagActionDispatcher, IBagActionDispatcherTrait}},
+    };
+
+    use bytebeasts::{
+        models::bag::{{Bag, bag}},
+        models::player::{{Player, player}},
+        models::potion::{{Potion, potion}},
+    };
+
+
+    // Helper function
+    // This function create the world and define the required models
+    #[test]
+     fn setup_world() -> (IWorldDispatcher, IBagActionDispatcher) {
+        let mut models = array![
+            bag::TEST_CLASS_HASH,
+            player::TEST_CLASS_HASH,
+            potion::TEST_CLASS_HASH,
+            
+        ];
+        
+        let world = spawn_test_world("bytebeasts", models);
+ 
+        let contract_address = world.deploy_contract('salt', bag_system::TEST_CLASS_HASH.try_into().unwrap());
+
+        let bag_system = IBagActionDispatcher { contract_address };
+
+        world.grant_writer(dojo::utils::bytearray_hash(@"bytebeasts"), contract_address);
+ 
+        (world, bag_system)
+    }
+
+
+    #[test]
+    fn test_setup() {
+        let (_, _,) = setup_world();
+    }
+}


### PR DESCRIPTION
## Summary
- Closes #32 
- This PR introduces a new system to handle the potions of the `bag` model.
- It includes 3 functionalities:
   - Init bag
   - Add item(potion)
   - Take out item(potion)
- Unit tests for the system. 

## Notes
- sozo commands running.

## Tests
![image](https://github.com/user-attachments/assets/41225d43-d6d4-4aa6-86ef-b5f76e1e7251)
