### PR TITLE
feat: Add prerequisites section to the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,58 +24,58 @@ Read the full tutorial [here](https://book.dojoengine.org/tutorial/dojo-starter)
 
 ## Prerequisites
 
-To work with Dojo, you need to have Git, Rust and Scarb installed on your PC to satisfy Dojo dependencies. You can install them with the following steps:
+To be able to run the ByteBeasts backend you need to have Git, Rust and Scarb installed on your PC to satisfy Dojo dependencies. You can install them with the following steps:
 
-#### Install Rust
+### Install Rust
 
 Go to the [Rust installation page](https://doc.rust-lang.org/book/ch01-01-installation.html#installing-rustup-on-linux-or-macos)
 
 After installing Rust, ensure your `PATH` environment variable includes the Cargo bin directory (usually `$HOME/.cargo/bin`).
 
-#### Install Git
+### Install Git
 Go to the [Git installation page](https://git-scm.com/downloads) and follow the instructions for your operating system to install Git.
 
-#### Install Scarb
+### Install Scarb
 The Dojo toolchain integrates [Scarb](https://docs.swmansion.com/scarb/) to build and run Dojo projects, installation instructions are [here](https://docs.swmansion.com/scarb/download.html).
 
-### Install Dojo using `dojoup`
+## Install Dojo using `dojoup`
 
 You can install with the `dojoup` version manager which enables you to easily install, update and manage your Dojo installation.
 
-#### Install dojoup
-```
+### Install dojoup
+```bash
 curl -L https://install.dojoengine.org | bash
 ```
-#### Install the latest Dojo release
-```
+### Install the latest Dojo release
+```bash
 dojoup
 ```
 
-### Install Dojo using `asdf`
+## Install Dojo using `asdf`
 
 You can alternatively use the `asdf` package manager to install and manage your Dojo installation.
 
-#### Install asdf
+### Install asdf
 
 Follow the [asdf installation instructions](https://asdf-vm.com/guide/getting-started.html)
 
-#### Add the asdf-dojo plugin
+### Add the asdf-dojo plugin
 
-```
+```bash
 asdf plugin add dojo https://github.com/dojoengine/asdf-dojo
 ```
 
-#### Install the latest or a specific version
+### Install the latest or a specific version
 
-```
+```bash
 asdf install dojo latest      # For the latest version
 asdf install dojo 0.7.0       # For a specific version
 
 ```
 
-#### Set the global or local version
+### Set the global or local version
 
-```
+```bash
 asdf global dojo latest       # Set globally
 asdf local dojo 0.7.0         # Set locally in your project directory
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,65 @@ The official Byte Beasts guide, the quickest and most streamlined way to get you
 
 Read the full tutorial [here](https://book.dojoengine.org/tutorial/dojo-starter).
 
+## Prerequisites
+
+To work with Dojo, you need to have Git, Rust and Scarb installed on your PC to satisfy Dojo dependencies. You can install them with the following steps:
+
+#### Install Rust
+
+Go to the [Rust installation page](https://doc.rust-lang.org/book/ch01-01-installation.html#installing-rustup-on-linux-or-macos)
+
+After installing Rust, ensure your `PATH` environment variable includes the Cargo bin directory (usually `$HOME/.cargo/bin`).
+
+#### Install Git
+Go to the [Git installation page](https://git-scm.com/downloads) and follow the instructions for your operating system to install Git.
+
+#### Install Scarb
+The Dojo toolchain integrates [Scarb](https://docs.swmansion.com/scarb/) to build and run Dojo projects, installation instructions are [here](https://docs.swmansion.com/scarb/download.html).
+
+### Install Dojo using `dojoup`
+
+You can install with the `dojoup` version manager which enables you to easily install, update and manage your Dojo installation.
+
+#### Install dojoup
+```
+curl -L https://install.dojoengine.org | bash
+```
+#### Install the latest Dojo release
+```
+dojoup
+```
+
+### Install Dojo using `asdf`
+
+You can alternatively use the `asdf` package manager to install and manage your Dojo installation.
+
+#### Install asdf
+
+Follow the [asdf installation instructions](https://asdf-vm.com/guide/getting-started.html)
+
+#### Add the asdf-dojo plugin
+
+```
+asdf plugin add dojo https://github.com/dojoengine/asdf-dojo
+```
+
+#### Install the latest or a specific version
+
+```
+asdf install dojo latest      # For the latest version
+asdf install dojo 0.7.0       # For a specific version
+
+```
+
+#### Set the global or local version
+
+```
+asdf global dojo latest       # Set globally
+asdf local dojo 0.7.0         # Set locally in your project directory
+
+```
+
 ## Running Locally
 
 #### Terminal one (Make sure this is running)
@@ -50,3 +109,4 @@ Whether it's fixing bugs, improving documentation, or adding new features, your 
 
 ## Communication channel
 If you're a contributor or would like to connect with the project maintainers, feel free to join our [Telegram](https://t.me/+-84e2pqLtqNkZDAx) group!
+


### PR DESCRIPTION
📝 Summary
- Closes #48 

🔄 Changes Made
- Prerequisites section for README 
  - Added prerequisited section to the `README.md`
  
🔧 Tests Results

🔜 Next Steps


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
	- Enhanced the README with a new section on prerequisites for running the ByteBeasts backend, including installation instructions for Git, Rust, and Scarb.
	- Introduced two methods for installing Dojo: using the `dojoup` version manager and the `asdf` package manager, with detailed guidance for each method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->