### PR TITLE
SeasonModel & Tests

### DIFF
--- a/manifests/dev/base/abis/models/bytebeasts-Season-52f8bbb6.json
+++ b/manifests/dev/base/abis/models/bytebeasts-Season-52f8bbb6.json
@@ -1,0 +1,437 @@
+[
+  {
+    "type": "impl",
+    "name": "DojoModelImpl",
+    "interface_name": "dojo::model::model::IModel"
+  },
+  {
+    "type": "struct",
+    "name": "core::byte_array::ByteArray",
+    "members": [
+      {
+        "name": "data",
+        "type": "core::array::Array::<core::bytes_31::bytes31>"
+      },
+      {
+        "name": "pending_word",
+        "type": "core::felt252"
+      },
+      {
+        "name": "pending_word_len",
+        "type": "core::integer::u32"
+      }
+    ]
+  },
+  {
+    "type": "enum",
+    "name": "core::option::Option::<core::integer::u32>",
+    "variants": [
+      {
+        "name": "Some",
+        "type": "core::integer::u32"
+      },
+      {
+        "name": "None",
+        "type": "()"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<core::integer::u8>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<core::integer::u8>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "dojo::model::layout::FieldLayout",
+    "members": [
+      {
+        "name": "selector",
+        "type": "core::felt252"
+      },
+      {
+        "name": "layout",
+        "type": "dojo::model::layout::Layout"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<dojo::model::layout::FieldLayout>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<dojo::model::layout::FieldLayout>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<dojo::model::layout::Layout>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<dojo::model::layout::Layout>"
+      }
+    ]
+  },
+  {
+    "type": "enum",
+    "name": "dojo::model::layout::Layout",
+    "variants": [
+      {
+        "name": "Fixed",
+        "type": "core::array::Span::<core::integer::u8>"
+      },
+      {
+        "name": "Struct",
+        "type": "core::array::Span::<dojo::model::layout::FieldLayout>"
+      },
+      {
+        "name": "Tuple",
+        "type": "core::array::Span::<dojo::model::layout::Layout>"
+      },
+      {
+        "name": "Array",
+        "type": "core::array::Span::<dojo::model::layout::Layout>"
+      },
+      {
+        "name": "ByteArray",
+        "type": "()"
+      },
+      {
+        "name": "Enum",
+        "type": "core::array::Span::<dojo::model::layout::FieldLayout>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<core::felt252>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<core::felt252>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "dojo::model::introspect::Member",
+    "members": [
+      {
+        "name": "name",
+        "type": "core::felt252"
+      },
+      {
+        "name": "attrs",
+        "type": "core::array::Span::<core::felt252>"
+      },
+      {
+        "name": "ty",
+        "type": "dojo::model::introspect::Ty"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<dojo::model::introspect::Member>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<dojo::model::introspect::Member>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "dojo::model::introspect::Struct",
+    "members": [
+      {
+        "name": "name",
+        "type": "core::felt252"
+      },
+      {
+        "name": "attrs",
+        "type": "core::array::Span::<core::felt252>"
+      },
+      {
+        "name": "children",
+        "type": "core::array::Span::<dojo::model::introspect::Member>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<(core::felt252, dojo::model::introspect::Ty)>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<(core::felt252, dojo::model::introspect::Ty)>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "dojo::model::introspect::Enum",
+    "members": [
+      {
+        "name": "name",
+        "type": "core::felt252"
+      },
+      {
+        "name": "attrs",
+        "type": "core::array::Span::<core::felt252>"
+      },
+      {
+        "name": "children",
+        "type": "core::array::Span::<(core::felt252, dojo::model::introspect::Ty)>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<dojo::model::introspect::Ty>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<dojo::model::introspect::Ty>"
+      }
+    ]
+  },
+  {
+    "type": "enum",
+    "name": "dojo::model::introspect::Ty",
+    "variants": [
+      {
+        "name": "Primitive",
+        "type": "core::felt252"
+      },
+      {
+        "name": "Struct",
+        "type": "dojo::model::introspect::Struct"
+      },
+      {
+        "name": "Enum",
+        "type": "dojo::model::introspect::Enum"
+      },
+      {
+        "name": "Tuple",
+        "type": "core::array::Span::<dojo::model::introspect::Ty>"
+      },
+      {
+        "name": "Array",
+        "type": "core::array::Span::<dojo::model::introspect::Ty>"
+      },
+      {
+        "name": "ByteArray",
+        "type": "()"
+      }
+    ]
+  },
+  {
+    "type": "interface",
+    "name": "dojo::model::model::IModel",
+    "items": [
+      {
+        "type": "function",
+        "name": "name",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::byte_array::ByteArray"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "namespace",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::byte_array::ByteArray"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "tag",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::byte_array::ByteArray"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "version",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::integer::u8"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "selector",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::felt252"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "name_hash",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::felt252"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "namespace_hash",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::felt252"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "unpacked_size",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::option::Option::<core::integer::u32>"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "packed_size",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::option::Option::<core::integer::u32>"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "layout",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "dojo::model::layout::Layout"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "schema",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "dojo::model::introspect::Ty"
+          }
+        ],
+        "state_mutability": "view"
+      }
+    ]
+  },
+  {
+    "type": "impl",
+    "name": "seasonImpl",
+    "interface_name": "bytebeasts::models::season::Iseason"
+  },
+  {
+    "type": "enum",
+    "name": "core::bool",
+    "variants": [
+      {
+        "name": "False",
+        "type": "()"
+      },
+      {
+        "name": "True",
+        "type": "()"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "bytebeasts::models::season::Season",
+    "members": [
+      {
+        "name": "season_id",
+        "type": "core::integer::u64"
+      },
+      {
+        "name": "name",
+        "type": "core::felt252"
+      },
+      {
+        "name": "start_date",
+        "type": "core::integer::u64"
+      },
+      {
+        "name": "end_date",
+        "type": "core::integer::u64"
+      },
+      {
+        "name": "is_active",
+        "type": "core::bool"
+      },
+      {
+        "name": "active_players",
+        "type": "core::array::Array::<core::integer::u64>"
+      }
+    ]
+  },
+  {
+    "type": "interface",
+    "name": "bytebeasts::models::season::Iseason",
+    "items": [
+      {
+        "type": "function",
+        "name": "ensure_abi",
+        "inputs": [
+          {
+            "name": "model",
+            "type": "bytebeasts::models::season::Season"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "view"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "bytebeasts::models::season::season::Event",
+    "kind": "enum",
+    "variants": []
+  }
+]

--- a/manifests/dev/base/abis/models/bytebeasts-SeasonManager-57ed50e9.json
+++ b/manifests/dev/base/abis/models/bytebeasts-SeasonManager-57ed50e9.json
@@ -1,0 +1,451 @@
+[
+  {
+    "type": "impl",
+    "name": "DojoModelImpl",
+    "interface_name": "dojo::model::model::IModel"
+  },
+  {
+    "type": "struct",
+    "name": "core::byte_array::ByteArray",
+    "members": [
+      {
+        "name": "data",
+        "type": "core::array::Array::<core::bytes_31::bytes31>"
+      },
+      {
+        "name": "pending_word",
+        "type": "core::felt252"
+      },
+      {
+        "name": "pending_word_len",
+        "type": "core::integer::u32"
+      }
+    ]
+  },
+  {
+    "type": "enum",
+    "name": "core::option::Option::<core::integer::u32>",
+    "variants": [
+      {
+        "name": "Some",
+        "type": "core::integer::u32"
+      },
+      {
+        "name": "None",
+        "type": "()"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<core::integer::u8>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<core::integer::u8>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "dojo::model::layout::FieldLayout",
+    "members": [
+      {
+        "name": "selector",
+        "type": "core::felt252"
+      },
+      {
+        "name": "layout",
+        "type": "dojo::model::layout::Layout"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<dojo::model::layout::FieldLayout>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<dojo::model::layout::FieldLayout>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<dojo::model::layout::Layout>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<dojo::model::layout::Layout>"
+      }
+    ]
+  },
+  {
+    "type": "enum",
+    "name": "dojo::model::layout::Layout",
+    "variants": [
+      {
+        "name": "Fixed",
+        "type": "core::array::Span::<core::integer::u8>"
+      },
+      {
+        "name": "Struct",
+        "type": "core::array::Span::<dojo::model::layout::FieldLayout>"
+      },
+      {
+        "name": "Tuple",
+        "type": "core::array::Span::<dojo::model::layout::Layout>"
+      },
+      {
+        "name": "Array",
+        "type": "core::array::Span::<dojo::model::layout::Layout>"
+      },
+      {
+        "name": "ByteArray",
+        "type": "()"
+      },
+      {
+        "name": "Enum",
+        "type": "core::array::Span::<dojo::model::layout::FieldLayout>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<core::felt252>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<core::felt252>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "dojo::model::introspect::Member",
+    "members": [
+      {
+        "name": "name",
+        "type": "core::felt252"
+      },
+      {
+        "name": "attrs",
+        "type": "core::array::Span::<core::felt252>"
+      },
+      {
+        "name": "ty",
+        "type": "dojo::model::introspect::Ty"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<dojo::model::introspect::Member>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<dojo::model::introspect::Member>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "dojo::model::introspect::Struct",
+    "members": [
+      {
+        "name": "name",
+        "type": "core::felt252"
+      },
+      {
+        "name": "attrs",
+        "type": "core::array::Span::<core::felt252>"
+      },
+      {
+        "name": "children",
+        "type": "core::array::Span::<dojo::model::introspect::Member>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<(core::felt252, dojo::model::introspect::Ty)>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<(core::felt252, dojo::model::introspect::Ty)>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "dojo::model::introspect::Enum",
+    "members": [
+      {
+        "name": "name",
+        "type": "core::felt252"
+      },
+      {
+        "name": "attrs",
+        "type": "core::array::Span::<core::felt252>"
+      },
+      {
+        "name": "children",
+        "type": "core::array::Span::<(core::felt252, dojo::model::introspect::Ty)>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<dojo::model::introspect::Ty>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<dojo::model::introspect::Ty>"
+      }
+    ]
+  },
+  {
+    "type": "enum",
+    "name": "dojo::model::introspect::Ty",
+    "variants": [
+      {
+        "name": "Primitive",
+        "type": "core::felt252"
+      },
+      {
+        "name": "Struct",
+        "type": "dojo::model::introspect::Struct"
+      },
+      {
+        "name": "Enum",
+        "type": "dojo::model::introspect::Enum"
+      },
+      {
+        "name": "Tuple",
+        "type": "core::array::Span::<dojo::model::introspect::Ty>"
+      },
+      {
+        "name": "Array",
+        "type": "core::array::Span::<dojo::model::introspect::Ty>"
+      },
+      {
+        "name": "ByteArray",
+        "type": "()"
+      }
+    ]
+  },
+  {
+    "type": "interface",
+    "name": "dojo::model::model::IModel",
+    "items": [
+      {
+        "type": "function",
+        "name": "name",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::byte_array::ByteArray"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "namespace",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::byte_array::ByteArray"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "tag",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::byte_array::ByteArray"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "version",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::integer::u8"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "selector",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::felt252"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "name_hash",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::felt252"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "namespace_hash",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::felt252"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "unpacked_size",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::option::Option::<core::integer::u32>"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "packed_size",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::option::Option::<core::integer::u32>"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "layout",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "dojo::model::layout::Layout"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "schema",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "dojo::model::introspect::Ty"
+          }
+        ],
+        "state_mutability": "view"
+      }
+    ]
+  },
+  {
+    "type": "impl",
+    "name": "season_managerImpl",
+    "interface_name": "bytebeasts::models::season::Iseason_manager"
+  },
+  {
+    "type": "enum",
+    "name": "core::bool",
+    "variants": [
+      {
+        "name": "False",
+        "type": "()"
+      },
+      {
+        "name": "True",
+        "type": "()"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "bytebeasts::models::season::Season",
+    "members": [
+      {
+        "name": "season_id",
+        "type": "core::integer::u64"
+      },
+      {
+        "name": "name",
+        "type": "core::felt252"
+      },
+      {
+        "name": "start_date",
+        "type": "core::integer::u64"
+      },
+      {
+        "name": "end_date",
+        "type": "core::integer::u64"
+      },
+      {
+        "name": "is_active",
+        "type": "core::bool"
+      },
+      {
+        "name": "active_players",
+        "type": "core::array::Array::<core::integer::u64>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "bytebeasts::models::season::SeasonManager",
+    "members": [
+      {
+        "name": "manager_id",
+        "type": "core::integer::u64"
+      },
+      {
+        "name": "seasons",
+        "type": "core::array::Array::<bytebeasts::models::season::Season>"
+      }
+    ]
+  },
+  {
+    "type": "interface",
+    "name": "bytebeasts::models::season::Iseason_manager",
+    "items": [
+      {
+        "type": "function",
+        "name": "ensure_abi",
+        "inputs": [
+          {
+            "name": "model",
+            "type": "bytebeasts::models::season::SeasonManager"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "view"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "bytebeasts::models::season::season_manager::Event",
+    "kind": "enum",
+    "variants": []
+  }
+]

--- a/manifests/dev/base/models/bytebeasts-Season-52f8bbb6.toml
+++ b/manifests/dev/base/models/bytebeasts-Season-52f8bbb6.toml
@@ -1,0 +1,36 @@
+kind = "DojoModel"
+class_hash = "0x7a8bee9882da24371365f5e6531ed532e9deb91c5b5173d7d230dec53c5c337"
+original_class_hash = "0x7a8bee9882da24371365f5e6531ed532e9deb91c5b5173d7d230dec53c5c337"
+abi = "manifests/dev/base/abis/models/bytebeasts-Season-52f8bbb6.json"
+tag = "bytebeasts-Season"
+manifest_name = "bytebeasts-Season-52f8bbb6"
+
+[[members]]
+name = "season_id"
+type = "u64"
+key = true
+
+[[members]]
+name = "name"
+type = "felt252"
+key = false
+
+[[members]]
+name = "start_date"
+type = "u64"
+key = false
+
+[[members]]
+name = "end_date"
+type = "u64"
+key = false
+
+[[members]]
+name = "is_active"
+type = "bool"
+key = false
+
+[[members]]
+name = "active_players"
+type = "Array<u64>"
+key = false

--- a/manifests/dev/base/models/bytebeasts-SeasonManager-57ed50e9.toml
+++ b/manifests/dev/base/models/bytebeasts-SeasonManager-57ed50e9.toml
@@ -1,0 +1,16 @@
+kind = "DojoModel"
+class_hash = "0x6795f48396469dd05f2357a86bf37d0392c24d938bc0972006834ac365b62c"
+original_class_hash = "0x6795f48396469dd05f2357a86bf37d0392c24d938bc0972006834ac365b62c"
+abi = "manifests/dev/base/abis/models/bytebeasts-SeasonManager-57ed50e9.json"
+tag = "bytebeasts-SeasonManager"
+manifest_name = "bytebeasts-SeasonManager-57ed50e9"
+
+[[members]]
+name = "manager_id"
+type = "u64"
+key = true
+
+[[members]]
+name = "seasons"
+type = "Array<Season>"
+key = false

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -28,6 +28,7 @@ mod models {
     mod achievement_type;
     mod achievements;
     mod tournament;
+    mod season;
 }
 
 mod tests {

--- a/src/models/season.cairo
+++ b/src/models/season.cairo
@@ -1,0 +1,411 @@
+use array::ArrayTrait;
+use option::OptionTrait;
+
+#[derive(Drop, Serde, Clone)]
+#[dojo::model]
+pub struct Season {
+    #[key]
+    pub season_id: u64,
+    pub name: felt252,
+    pub start_date: u64,
+    pub end_date: u64,
+    pub is_active: bool,
+    pub active_players: Array<u64>,
+}
+
+#[derive(Drop, Serde, Clone)]
+#[dojo::model]
+pub struct SeasonManager {
+    #[key]
+    pub manager_id: u64,
+    pub seasons: Array<Season>,
+}
+
+#[generate_trait]
+impl SeasonManagerImpl of SeasonManagerTrait {
+    fn create_season(
+        ref self: SeasonManager,
+        season_id: u64,
+        name: felt252,
+        start_date: u64,
+        end_date: u64,
+        is_active: bool,
+        active_players: Array<u64>
+    ) -> felt252 {
+        let new_season = Season {
+            season_id,
+            name,
+            start_date,
+            end_date,
+            is_active,
+            active_players,
+        };
+
+        self.seasons.append(new_season);
+        'Season created successfully'
+    }
+
+    fn update_season(
+        ref self: SeasonManager,
+        season_id: u64,
+        new_name: Option<felt252>,
+        new_start_date: Option<u64>,
+        new_end_date: Option<u64>,
+        new_is_active: Option<bool>,
+    ) -> felt252 {
+
+        let mut current_seasons = self.seasons;
+        self.seasons = ArrayTrait::new();
+        let mut found = false;
+        let mut i = 0;
+        loop {
+            if i == current_seasons.len() {
+                break;
+            }
+
+            let season = current_seasons.at(i).clone();
+
+            if season.season_id == season_id {
+                found = true;
+                let updated_season = Season {
+                    season_id: season.season_id,
+                    name: match new_name {
+                        Option::Some(new_name) => new_name,
+                        Option::None => season.name,
+                    },
+                    start_date: match new_start_date {
+                        Option::Some(new_start_date) => new_start_date,
+                        Option::None => season.start_date,
+                    },
+                    end_date: match new_end_date {
+                        Option::Some(end_date) => end_date,
+                        Option::None => season.end_date,
+                    },
+                    is_active: match new_is_active {
+                        Option::Some(is_active) => is_active,
+                        Option::None => season.is_active,
+                    },
+                    active_players: season.active_players.clone(),
+                };
+
+                self.seasons.append(updated_season);
+            } else {
+
+                self.seasons.append(season.clone());
+            }
+
+            i += 1;
+        };
+
+        match found {
+            true => 'Season updated successfully',
+            false => 'Season not found',
+        }
+    }
+    
+    fn get_season(self: SeasonManager, season_id: u64) -> Season {
+        let mut i = 0; 
+        loop {
+            if i == self.seasons.len() {
+                break;
+            }
+    
+            if *self.seasons.at(i).season_id == season_id {
+                break;
+            }
+    
+            i += 1;
+        };
+    
+        self.seasons.at(i).clone()
+    }
+
+    fn get_active_seasons(self: SeasonManager) -> Array<Season> {
+        let mut active_seasons = ArrayTrait::new();
+
+        let mut i = 0;
+        loop {
+            if i == self.seasons.len() {
+                break;
+            }
+
+            let season = self.seasons.at(i);
+            if *season.is_active {
+                active_seasons.append(season.clone());
+            }
+
+            i += 1;
+        };
+
+        active_seasons
+    }
+
+fn delete_season(ref self: SeasonManager, season_id: u64) -> felt252 {
+    let mut updated_seasons = ArrayTrait::new();
+    let mut found = false;
+
+    let mut i = 0;
+    loop {
+        if i == self.seasons.len() {
+            break;
+        }
+
+        let season = self.seasons.at(i);
+        if *season.season_id != season_id {
+            updated_seasons.append(season.clone());
+        } else {
+            found = true;
+        }
+
+        i += 1;
+    };
+
+    self.seasons = updated_seasons;
+
+    match found {
+        true => 'Season deleted successfully',
+        false => 'Season not found',
+    }
+}
+
+fn update_active_players(
+    ref self: SeasonManager,
+    season_id: u64,
+    new_active_players: Array<u64>
+) -> felt252 {
+
+    let mut current_seasons = self.seasons;
+    self.seasons = ArrayTrait::new();
+    let mut found = false;
+    let mut i = 0;
+    loop {
+        if i == current_seasons.len() {
+            break;
+        }
+        let season = current_seasons.at(i).clone();
+
+        if season.season_id == season_id {
+            found = true;
+            let updated_season = Season {
+                season_id: season.season_id,
+                name: season.name,
+                start_date: season.start_date,
+                end_date: season.end_date ,
+                is_active: season.is_active,
+                active_players: new_active_players.clone(),
+            };
+            self.seasons.append(updated_season);
+        } else {
+
+            self.seasons.append(season.clone());
+        }
+
+        i += 1;
+    };
+
+    match found {
+        true => 'active players updated',
+        false => 'Season not found',
+    }
+}
+
+fn add_player_to_season(ref self: SeasonManager, season_id: u64, player_id: u64) -> felt252 {
+    let mut i = 0;
+    let mut updated = false;
+    let mut result_message = 'Season not found';
+    loop {
+        if i == self.seasons.len() {
+            break;
+        }
+
+        let mut season = self.seasons.at(i).clone();
+
+        if season.season_id == season_id {
+            let mut j = 0;
+            let mut player_exists = false;
+
+            loop {
+                if j == season.active_players.len() {
+                    break;
+                }
+
+                if *season.active_players.at(j) == player_id {
+                    player_exists = true;
+                    break;
+                }
+
+                j += 1;
+            };
+
+            if player_exists {
+                result_message = 'Player already in season';
+                break;
+            }
+            season.active_players.append(player_id);
+            self.update_active_players(
+                season_id: season.season_id,
+                new_active_players: season.active_players,
+            );
+            updated = true;
+            result_message = 'Player added successfully';
+            break;
+        }
+
+        i += 1;
+    };
+
+    result_message
+}
+
+
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Season, SeasonManager, SeasonManagerImpl};
+    use array::ArrayTrait;
+
+    #[test]
+    fn test_create_season() {
+        let mut manager = SeasonManager {
+            manager_id: 1,
+            seasons: ArrayTrait::new(),
+        };
+
+        let result = manager.create_season(1, 'Season One', 1672531200, 1675219599, true, ArrayTrait::new());
+        assert(result == 'Season created successfully', 'Failed to create a season');
+        assert(manager.seasons.len() == 1, 'list should contain 1 item');
+    }
+
+    #[test]
+    fn test_update_season() {
+        let mut manager = SeasonManager {
+            manager_id: 1,
+            seasons: ArrayTrait::new(),
+        };
+
+        manager.create_season(1, 'Initial Season', 1672531200, 1675219599, true, ArrayTrait::new());
+
+        let result = manager.update_season(
+            1,
+            Option::Some('Updated Season'),
+            Option::None,
+            Option::Some(1677803999),
+            Option::Some(false),
+        );
+
+        assert(result == 'Season updated successfully', 'Failed to update the season');
+        let updated_season = manager.get_season(1);
+        assert(updated_season.name == 'Updated Season', 'Name was not updated');
+        assert(updated_season.end_date == 1677803999, 'End date was not updated');
+        assert(!updated_season.is_active, 'is_active was not updated');
+    }
+
+    #[test]
+    fn test_get_season() {
+        let mut manager = SeasonManager {
+            manager_id: 1,
+            seasons: ArrayTrait::new(),
+        };
+
+        manager.create_season(1, 'Season A', 1672531200, 1675219599, true, ArrayTrait::new());
+        let season = manager.get_season(1);
+        assert(season.season_id == 1, 'Incorrect season ID retrieved');
+        assert(season.name == 'Season A', 'Incorrect season name retrieved');
+    }
+
+    #[test]
+    fn test_get_active_seasons() {
+        let mut manager = SeasonManager {
+            manager_id: 1,
+            seasons: ArrayTrait::new(),
+        };
+
+        manager.create_season(1, 'Active Season', 1672531200, 1675219599, true, ArrayTrait::new());
+        manager.create_season(2, 'Inactive Season', 1672531200, 1675219599, false, ArrayTrait::new());
+
+        let active_seasons = manager.get_active_seasons();
+        assert(active_seasons.len() == 1, 'one active season should exist');
+        assert(*active_seasons.at(0).season_id == 1, 'wrong active season retrieved');
+    }
+
+    #[test]
+    fn test_delete_season() {
+        let mut manager = SeasonManager {
+            manager_id: 1,
+            seasons: ArrayTrait::new(),
+        };
+
+        manager.create_season(1, 'To Be Deleted', 1672531200, 1675219599, true, ArrayTrait::new());
+        let result = manager.delete_season(1);
+        assert(result == 'Season deleted successfully', 'Failed to delete the season');
+        assert(manager.seasons.len() == 0, 'list should be empty');
+    }
+
+    #[test]
+    fn test_update_active_players() {
+        let mut manager = SeasonManager {
+            manager_id: 1,
+            seasons: ArrayTrait::new(),
+        };
+        manager.create_season(1, 'Test Season', 1672531200, 1675219599, true, ArrayTrait::new());
+
+        let mut new_active_players = ArrayTrait::new();
+        new_active_players.append(101);
+        new_active_players.append(102);
+
+        let result = manager.update_active_players(1, new_active_players.clone());
+        assert(result == 'active players updated', 'unsuccessful player update');
+
+        let updated_season = manager.get_season(1);
+        assert(updated_season.active_players.len() == 2, 'players count is incorrect');
+        assert(*updated_season.active_players.at(0) == 101, 'First player ID is incorrect');
+        assert(*updated_season.active_players.at(1) == 102, 'Second player ID is incorrect');
+    }
+
+    #[test]
+    fn test_add_player_to_season() {
+    let mut manager = SeasonManager {
+        manager_id: 1,
+        seasons: ArrayTrait::new(),
+    };
+    manager.create_season(1, 'Test Season', 1672531200, 1675219599, true, ArrayTrait::new() );
+
+    let result = manager.add_player_to_season(1, 101);
+    assert(result == 'Player added successfully', 'Failed to add player to season');
+
+    let season = manager.clone().get_season(1);
+    assert(season.active_players.len() == 1, 'Player count is incorrect');
+    assert(*season.active_players.at(0) == 101, 'Player ID is incorrect');
+
+    let duplicate_result = manager.add_player_to_season(1, 101);
+    assert(duplicate_result == 'Player already in season', 'should fail');
+
+    let season_after_duplicate = manager.clone().get_season(1);
+    assert(season_after_duplicate.active_players.len() == 1, 'count should not increase');
+
+    let non_existent_result = manager.add_player_to_season(99, 102);
+    assert(non_existent_result == 'Season not found', 'Non-existent season addition');
+    }
+
+    #[test]
+    fn test_non_existent_season_operations() {
+        let mut manager = SeasonManager {
+            manager_id: 1,
+            seasons: ArrayTrait::new(),
+        };
+
+        let delete_result = manager.delete_season(99);
+        assert(delete_result == 'Season not found', 'Should return Season not found');
+
+        let update_result = manager.update_season(
+            99,
+            Option::Some('Nonexistent'),
+            Option::None,
+            Option::None,
+            Option::None,
+        );
+        assert(update_result == 'Season not found', 'Should return Season not found');
+    }
+}
+


### PR DESCRIPTION
Implemented seasonModel and related functions with tests

Closes #89 
![suzo test1](https://github.com/user-attachments/assets/3bba7f31-70b9-41f2-bb7e-412229114b7a)
![suzo test2](https://github.com/user-attachments/assets/fe804e41-5f5c-4615-a3f0-0cac592b6544)
![sozo build](https://github.com/user-attachments/assets/ac97f896-3fcc-4383-973e-400361b6e525)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `season` module to manage game seasons.
	- Added functionality to create, update, retrieve, and delete seasons.
	- Implemented methods to manage active players within seasons.
	- Added a `SeasonManager` to oversee multiple seasons.
- **Tests**
	- Included unit tests for all new methods to ensure expected functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->